### PR TITLE
Fix "ReferenceError: event is not defined" errors in Firefox

### DIFF
--- a/touch-dnd.js
+++ b/touch-dnd.js
@@ -59,8 +59,8 @@
     this.parent = parent
     this.el = el
     this.el.css('-ms-touch-action', 'none').css('touch-action', 'none')
-    this.origin.x = event.changedTouches ? event.changedTouches[0].pageX : e.pageX
-    this.origin.y = event.changedTouches ? event.changedTouches[0].pageY : e.pageY
+    this.origin.x = e.changedTouches ? e.changedTouches[0].pageX : e.pageX
+    this.origin.y = e.changedTouches ? e.changedTouches[0].pageY : e.pageY
     this.origin.transform  = vendorify('transform', this.el[0])
     this.origin.transition = vendorify('transition', this.el[0])
     var rect = this.el[0].getBoundingClientRect()
@@ -98,8 +98,8 @@
   Dragging.prototype.move = function(e) {
     if (!this.el) return
 
-    var clientX = e.clientX || event.touches[0].clientX
-      , clientY = e.clientY || event.touches[0].clientY
+    var clientX = e.clientX || e.touches[0].clientX
+      , clientY = e.clientY || e.touches[0].clientY
     var over = document.elementFromPoint(clientX, clientY)
 
     var deltaX = this.lastX - clientX


### PR DESCRIPTION
`event` was referenced in several places despite the event actually being
assigned to `e`.
