### PR TITLE
Update README.md and add entry for version 1.2.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- introduce support for module loaders like require.js
+- add type definition file for TypeScript
+
 ## 1.1.2
 
 - fix droppable `receiveHandler` #55
@@ -85,13 +90,13 @@ We are `1.0.0` now, because there are no reasons to hang out a at `0.x` versioni
 
 ### Bugfixes
 
-* fix z-index
+- fix z-index
 
 ## 0.4.1
 
 ### Bugfixes
 
-* restore IE touch compatibility
+- restore IE touch compatibility
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
 # touch-dnd
 
-Advanced touch-compatible Drag'n'Drop library providing Draggable, Droppable and Sortable for Zepto.js and jQuery (for Zepto, you have to include its `data` module).
+Advanced touch-compatible Drag'n'Drop library providing Draggable, Droppable and Sortable for Zepto.js and jQuery
+(for Zepto, you have to include its `data` module).
 
 [![NPM](http://img.shields.io/npm/v/touch-dnd.svg?style=flat)](https://npmjs.org/package/touch-dnd)
-
 
 **Status:** Tested with current version of Chrome (Mac & Android), Safari (Mac & iOS), Opera Next, Firefox and IE  
 **Documentation:** [ma.rkusa.st/touch-dnd](http://ma.rkusa.st/touch-dnd)
 
 #### Why?
 
-This library is a derivative of [zepto-dnd](https://github.com/rkusa/zepto-dnd), which reached the limits of the native HTML5 Drag'n'Drop API, especially in terms of dragging helper accessibility and - most important - in terms of compatiblity with touch devices.
+This library is a derivative of [zepto-dnd](https://github.com/rkusa/zepto-dnd), which reached the limits of the native
+HTML5 Drag'n'Drop API, especially in terms of dragging helper accessibility and - most important - in terms of
+compatiblity with touch devices.
 
 #### Features
 
-* Draggable, Droppable & Sortable
-* **touch compatibility**
-* utilizes CSS3 [`transform`](http://www.w3schools.com/cssref/css3_pr_transform.asp) and [`transition`](http://www.w3schools.com/css/css3_transitions.asp) property for moving draggables around
-* [Zepto.js](http://zeptojs.com/) compatibility
+- Draggable, Droppable & Sortable
+- **touch compatibility**
+- utilizes CSS3 [`transform`](http://www.w3schools.com/cssref/css3_pr_transform.asp) and
+  [`transition`](http://www.w3schools.com/css/css3_transitions.asp) property for moving draggables around
+- [Zepto.js](http://zeptojs.com/) compatibility
 
 ## MIT License
-Copyright (c) 2013-2015 Markus Ast
+
+Copyright (c) 2013-2018 Markus Ast
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The year for the copyright in README.md was still 2015 so it was updated to 2018. Also the changelog for the current version was missing in CHANGELOG.md, so it was added as well.